### PR TITLE
Update Collection.php

### DIFF
--- a/app/code/community/RicardoMartins/OutofstockLast/Model/CatalogSearch/Mysql4/Fulltext/Collection.php
+++ b/app/code/community/RicardoMartins/OutofstockLast/Model/CatalogSearch/Mysql4/Fulltext/Collection.php
@@ -5,7 +5,7 @@ class RicardoMartins_OutofstockLast_Model_CatalogSearch_Mysql4_Fulltext_Collecti
    public function setOrder($attribute, $dir = 'desc')
     {
         if ($attribute == 'relevance') {
-            $this->getSelect()->order("on_top DESC")->order("relevance {$dir}");
+            $this->getSelect()->order("on_top DESC")->order("position {$dir}");
         }
         else {
             parent::setOrder('on_top', 'DESC');


### PR DESCRIPTION
Corrige erro Magento 1.9.3.8. A busca não encontra a coluna relevance.